### PR TITLE
Make /usr/local mutable.

### DIFF
--- a/tasks/base/bootc-tweaks.yaml
+++ b/tasks/base/bootc-tweaks.yaml
@@ -11,6 +11,12 @@
       mv /opt /var/opt
       ln -s /var/opt /opt
 
+- name: Set /usr/local mutable
+  shell:
+    cmd: |
+      mv /usr/local /var/usrlocal
+      ln -s /var/usrlocal /usr/local
+      
 - name: Reboot on Kernel Panic
   ansible.builtin.copy:
     content: |


### PR DESCRIPTION
Make /usr/local mutable.

For feature parity with Silverblue/Kinoite/Bluefin/Aurora/etc.